### PR TITLE
Code-splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 node_modules
-public/**/index.js*
+public/**/*.js*
 public/**/index.html
 public/**/glide.json
 .env

--- a/script/build.sh
+++ b/script/build.sh
@@ -13,11 +13,9 @@ do
     node public/$SLUG/manifest.js
     rm public/$SLUG/manifest.js
 
-
-    echo "<script type='module'>import './$SLUG.js';</script>" > public/$SLUG/index.html
+    # Now we build the actual column
+    esbuild $COLUMN --bundle --minify --sourcemap --outdir=public/$SLUG --external:fs --external:path --splitting --format=esm
+    echo "<script type='module'>import './$SLUG/$SLUG.js';</script>" > public/$SLUG/index.html
 done
-
-# Now we build the actual column
-esbuild src/columns/*.ts --bundle --minify --sourcemap --outdir=public/ --external:fs --external:path --splitting --format=esm
 
 ts-node script/build.ts

--- a/script/build.sh
+++ b/script/build.sh
@@ -14,8 +14,8 @@ do
     rm public/$SLUG/manifest.js
 
     # Now we build the actual column
-    esbuild $COLUMN --bundle --outdir=public/$SLUG --minify --sourcemap --external:fs --external:path --splitting --format=esm
-    echo "<script src='/$SLUG/$SLUG.js'></script>" > public/$SLUG/index.html
+    esbuild $COLUMN --bundle --outdir=public/$SLUG --external:fs --external:path --splitting --format=esm
+    echo "<script type='module'>import '$SLUG';</script>" > public/$SLUG/index.html
 done
 
 ts-node script/build.ts

--- a/script/build.sh
+++ b/script/build.sh
@@ -14,8 +14,8 @@ do
     rm public/$SLUG/manifest.js
 
     # Now we build the actual column
-    esbuild $COLUMN --bundle --outdir=public/$SLUG --external:fs --external:path --splitting --format=esm
-    echo "<script type='module'>import '$SLUG';</script>" > public/$SLUG/index.html
+    esbuild $COLUMN --bundle --minify --sourcemap --outdir=public/$SLUG --external:fs --external:path --splitting --format=esm
+    echo "<script type='module'>import './$SLUG';</script>" > public/$SLUG/index.html
 done
 
 ts-node script/build.ts

--- a/script/build.sh
+++ b/script/build.sh
@@ -15,7 +15,7 @@ do
 
     # Now we build the actual column
     esbuild $COLUMN --bundle --minify --sourcemap --outdir=public/$SLUG --external:fs --external:path --splitting --format=esm
-    echo "<script type='module'>import './$SLUG';</script>" > public/$SLUG/index.html
+    echo "<script type='module'>import './$SLUG.js';</script>" > public/$SLUG/index.html
 done
 
 ts-node script/build.ts

--- a/script/build.sh
+++ b/script/build.sh
@@ -14,8 +14,8 @@ do
     rm public/$SLUG/manifest.js
 
     # Now we build the actual column
-    esbuild $COLUMN --bundle --outfile=public/$SLUG/index.js --minify --sourcemap --external:fs --external:path
-    echo "<script src='/$SLUG/index.js'></script>" > public/$SLUG/index.html
+    esbuild $COLUMN --bundle --outdir=public/$SLUG --minify --sourcemap --external:fs --external:path --splitting --format=esm
+    echo "<script src='/$SLUG/$SLUG.js'></script>" > public/$SLUG/index.html
 done
 
 ts-node script/build.ts

--- a/script/build.sh
+++ b/script/build.sh
@@ -15,7 +15,7 @@ do
 
     # Now we build the actual column
     esbuild $COLUMN --bundle --minify --sourcemap --outdir=public/$SLUG --external:fs --external:path --splitting --format=esm
-    echo "<script type='module'>import './$SLUG.js';</script>" > public/$SLUG/index.html
+    echo "<script type='module'>import './$SLUG/$SLUG.js';</script>" > public/$SLUG/index.html
 done
 
 ts-node script/build.ts

--- a/script/build.sh
+++ b/script/build.sh
@@ -13,9 +13,11 @@ do
     node public/$SLUG/manifest.js
     rm public/$SLUG/manifest.js
 
-    # Now we build the actual column
-    esbuild $COLUMN --bundle --minify --sourcemap --outdir=public/$SLUG --external:fs --external:path --splitting --format=esm
-    echo "<script type='module'>import './$SLUG/$SLUG.js';</script>" > public/$SLUG/index.html
+
+    echo "<script type='module'>import './$SLUG.js';</script>" > public/$SLUG/index.html
 done
+
+# Now we build the actual column
+esbuild src/columns/*.ts --bundle --minify --sourcemap --outdir=public/ --external:fs --external:path --splitting --format=esm
 
 ts-node script/build.ts

--- a/src/columns/fetch.ts
+++ b/src/columns/fetch.ts
@@ -1,5 +1,4 @@
 import * as glide from "../glide";
-import jq from "jq-web";
 
 import { Cache } from "../cache";
 
@@ -13,6 +12,7 @@ const run: glide.Column = async (url, query) => {
   }
   let json = await cache.fetch(url.value);
   if (query.value !== undefined) {
+    const jq = await import("jq-web");
     json = jq.json(json, query.value);
   }
 


### PR DESCRIPTION
The `fetch` column is ~2-3MB because it includes `jq`. I tried to load `jq` lazily because it's not always used, and `fetch` alone is under `1kb`.