### PR TITLE
Update Excel Formula plugin about text

### DIFF
--- a/src/columns/fast-formula-parser.ts
+++ b/src/columns/fast-formula-parser.ts
@@ -50,7 +50,7 @@ export default glide.column({
     category: "Code",
     released: "direct",
     description: "Run Excel formulas",
-    about: `Uses [lesterlyu.github.io/fast-formula-parser](lesterlyu.github.io/fast-formula-parser) to evaluate Excel formulas.`,
+    about: `Uses [lesterlyu.github.io/fast-formula-parser](https://lesterlyu.github.io/fast-formula-parser) to evaluate Excel formulas.`,
     author: "Chris Ozgo <chris.ozgo@heyglide.com>",
     params: {
         formula: {


### PR DESCRIPTION
We need to update the excel formula about text because of a broken link on the marketing site.

Plugin page: https://www.glideapps.com/plugins/fast-formula-parser

The link points [here](https://www.glideapps.com/plugins/lesterlyu.github.io/fast-formula-parser) and it should point [here](https://lesterlyu.github.io/fast-formula-parser) instead.