### PR TITLE
Format duration column

### DIFF
--- a/src/columns/format-duration.ts
+++ b/src/columns/format-duration.ts
@@ -1,0 +1,25 @@
+import * as glide from "../glide";
+
+import { Duration } from "luxon";
+
+export default glide
+    .columnNamed("Format Duration")
+    .withDescription(`Format a duration in seconds into text like '1:30'.`)
+    .withReleased("direct")
+    .withCategory("Date & Time")
+    .withAuthor("luxon", "https://moment.github.io/luxon")
+    .withAbout(
+        `
+    Learn about date formatting in [luxon's documentation](https://moment.github.io/luxon/#/formatting?id=table-of-tokens).
+  `
+    )
+    .withStringResult()
+    .withRequiredNumberParam("seconds")
+    .withRequiredStringParam("format", "Format (e.g. mm:ss)")
+
+    .withTest({ seconds: 100, format: "mm:ss" }, "01:40")
+
+    .run(({ seconds, format }) => {
+        const duration = Duration.fromMillis(seconds * 1000);
+        return duration.toFormat(format);
+    });

--- a/src/columns/format-duration.ts
+++ b/src/columns/format-duration.ts
@@ -18,6 +18,8 @@ export default glide
     .withRequiredStringParam("format", "Format (e.g. mm:ss)")
 
     .withTest({ seconds: 100, format: "mm:ss" }, "01:40")
+    .withTest({ seconds: 1, format: "ss" }, "01")
+    .withTest({ seconds: 1000000000, format: "yy:MM:dd:hh:mm:ss" }, "31:08:19:01:46:40")
 
     .run(({ seconds, format }) => {
         const duration = Duration.fromMillis(seconds * 1000);


### PR DESCRIPTION
Adds a `Format Duration` column that can format a number of seconds as a text duration:

* `61` seconds with `m:ss` format becomes `1:01`
* `610` seconds with `mm:ss` format becomes `10:10`

Created to address [this forum thread](https://community.glideapps.com/t/can-i-convert-seconds-to-minutes).