### PR TITLE
feat: 🏷️ add deprecated fields to JSON and fetch

### DIFF
--- a/src/columns/create-json-object.ts
+++ b/src/columns/create-json-object.ts
@@ -80,6 +80,7 @@ const run: glide.Column = (
 
 export default glide.column({
     name: "Make JSON Object",
+    deprecated: true,
     category: "Code",
     released: "direct",
     description: "Returns a JSON Object String",

--- a/src/columns/fetch.ts
+++ b/src/columns/fetch.ts
@@ -26,6 +26,7 @@ const run: glide.Column = async (url, query) => {
 };
 
 export default glide.column({
+    deprecated: true,
     name: "Fetch JSON",
     category: "Data & APIs",
     released: "sandboxed",

--- a/src/columns/jq.ts
+++ b/src/columns/jq.ts
@@ -23,6 +23,7 @@ const run: glide.Column = async (json, query) => {
 
 export default glide.column({
     name: "Transform JSON",
+    deprecated: true,
     category: "Data & APIs",
     released: "direct",
     description: "Transform JSON with JQ",

--- a/src/components/REPL.tsx
+++ b/src/components/REPL.tsx
@@ -13,6 +13,7 @@ const REPL: React.VFC<ColumnDefinition<any>> = props => {
         run,
         tests = [],
         example = tests.length > 0 ? tests[0].params : {},
+        deprecated
     } = props;
 
     const [result, setResult] = useState<any>();
@@ -37,6 +38,12 @@ const REPL: React.VFC<ColumnDefinition<any>> = props => {
 
     return (
         <div className="p-5">
+            {deprecated ? (
+                <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4" role="alert">
+                    <p className="font-bold">Deprecated Column</p>
+                    <p className="my-2">This column has been deprecated. Glide apps which use it will continue to work, but will not appear in new configurations.</p>
+                </div>
+            ) : null}
             <div className="space-y-6">
                 {Object.values(params).map((p, i) => (
                     <div key={i}>

--- a/src/components/REPL.tsx
+++ b/src/components/REPL.tsx
@@ -41,7 +41,7 @@ const REPL: React.VFC<ColumnDefinition<any>> = props => {
             {deprecated ? (
                 <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4" role="alert">
                     <p className="font-bold">Deprecated Column</p>
-                    <p className="my-2">This column has been deprecated. Glide apps which use it will continue to work, but will not appear in new configurations.</p>
+                    <p className="my-2">Glide apps that already use this column will continue to work, but the column will no longer be available for new configurations.</p>
                 </div>
             ) : null}
             <div className="space-y-6">

--- a/src/glide.ts
+++ b/src/glide.ts
@@ -126,7 +126,7 @@ export function column<TColumnParams>(manifest: ColumnDefinition<TColumnParams>)
 export function toStrictManifest(convenient: ManifestConvenient<any>): Manifest {
     // We carefully pick out just the props in manifest, because more
     // could come in from the component.
-    const { name, category, released, description, author, result, params, about, video } = convenient;
+    const { name, category, released, description, author, result, params, about, video, deprecated } = convenient;
     const icon = getIconForManifest(convenient);
 
     return {
@@ -139,6 +139,7 @@ export function toStrictManifest(convenient: ManifestConvenient<any>): Manifest 
         about,
         icon,
         video,
+        deprecated,
         params: Object.entries(params).map(([name, param]) => ({
             name,
             ...param,

--- a/src/glide.ts
+++ b/src/glide.ts
@@ -85,6 +85,7 @@ type Released = "direct" | "sandboxed";
 export type Manifest = {
     name: string;
     category: Category;
+    deprecated?: boolean;
     released?: Released;
     description: string;
     author: string;


### PR DESCRIPTION
This is being done as part of Glide tasks: 

- [#21598 JSON Object: Deprecate "Transform JSON" computation](https://github.com/glideapps/glide/issues/21598)
- [#21599 JSON Object: Deprecate "Make JSON Object" computation](https://github.com/glideapps/glide/issues/21599)

Includes a deprecation banner on the REPL beautifully designed by ChatGPT:

<img width="1011" alt="image" src="https://github.com/glideapps/glide-code-columns/assets/389657/ec127c8e-2a46-4489-8803-62105b37c3f7">

Update, this may also deprecate Fetch as well, TBD based on @parkxdavid expert discovery 

https://github.com/glideapps/glide/issues/21604
