### PR TITLE
Remove link to jq (deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Glide Code Columns
 
-Code columns are an open source way to create computations around your data in [Glide Apps](https://glideapps.com) 
+Code columns are an open source way to create computations using your data in [Glide Apps](https://glideapps.com) 
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Glide Code Columns
 
-- [column.sh/jq](https://column.sh/jq): transform JSON with [jq queries](https://stedolan.github.io/jq/tutorial/).
+Code columns are an open source way to create computations around your data in [Glide Apps](https://glideapps.com) 
 
-## Development
+## Develop
 
 ```
 $ npm install

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "manifest": "script/build.sh",
-        "build": "npm test && npm run manifest && next build",
+        "build": "npm test && npm run manifest && NODE_OPTIONS=--openssl-legacy-provider next build",
         "export": "npm run manifest",
         "dev": "jest --watchAll & next dev",
         "start": "npm run dev",


### PR DESCRIPTION
Removes the link from the main README which has been deprecated. 